### PR TITLE
Fix invalid cluster name length error. 16 char max

### DIFF
--- a/05B - Working with Compute Targets.ipynb
+++ b/05B - Working with Compute Targets.ipynb
@@ -81,7 +81,7 @@
     "\n",
     "Azure ML supports a range of compute targets, which you can define in your workpace and use to run experiments; paying for the resources only when using them. When you set up the workspace in the first exercise, you created a compute cluster, so let's verify that exists (and if not, create it) so we can use it to run training experiments.\n",
     "\n",
-    "> **Important**: Change *your-compute-cluster* to the name of your compute cluster in the code below before running it! Cluster names must be globally unique names between 2 to 16 characters in length. Valid characters are letters, digits, and the - character."
+    "> **Important**: Change *compute-cluster* to the name of your compute cluster in the code below before running it! Cluster names must be globally unique names between 2 to 16 characters in length. Valid characters are letters, digits, and the - character."
    ]
   },
   {
@@ -93,7 +93,7 @@
     "from azureml.core.compute import ComputeTarget, AmlCompute\n",
     "from azureml.core.compute_target import ComputeTargetException\n",
     "\n",
-    "cluster_name = \"your-compute-cluster\"\n",
+    "cluster_name = \"compute-cluster\"\n",
     "\n",
     "try:\n",
     "    # Check for existing compute target\n",

--- a/06A - Creating a Pipeline.ipynb
+++ b/06A - Creating a Pipeline.ipynb
@@ -230,7 +230,7 @@
     "\n",
     "First, get the compute target you created in a previous lab (if it doesn't exist, it will be created).\n",
     "\n",
-    "> **Important**: Change *your-compute-cluster* to the name of your compute cluster in the code below before running it! Cluster names must be globally unique names between 2 to 16 characters in length. Valid characters are letters, digits, and the - character."
+    "> **Important**: Change *compute-cluster* to the name of your compute cluster in the code below before running it! Cluster names must be globally unique names between 2 to 16 characters in length. Valid characters are letters, digits, and the - character."
    ]
   },
   {
@@ -242,7 +242,7 @@
     "from azureml.core.compute import ComputeTarget, AmlCompute\n",
     "from azureml.core.compute_target import ComputeTargetException\n",
     "\n",
-    "cluster_name = \"your-compute-cluster\"\n",
+    "cluster_name = \"compute-cluster\"\n",
     "\n",
     "try:\n",
     "    # Check for existing compute target\n",

--- a/07B - Creating a Batch Inferencing Service.ipynb
+++ b/07B - Creating a Batch Inferencing Service.ipynb
@@ -180,7 +180,7 @@
     "\n",
     "We'll need a compute context for the pipeline, so we'll use the Azure ML compute cluster you used in the previous exercises (it will be created if it doesn't already exist).\n",
     "\n",
-    "> **Important**: Change *your-compute-cluster* to the name of your compute cluster in the code below before running it! Cluster names must be globally unique names between 2 to 16 characters in length. Valid characters are letters, digits, and the - character."
+    "> **Important**: Change *compute-cluster* to the name of your compute cluster in the code below before running it! Cluster names must be globally unique names between 2 to 16 characters in length. Valid characters are letters, digits, and the - character."
    ]
   },
   {
@@ -192,7 +192,7 @@
     "from azureml.core.compute import ComputeTarget, AmlCompute\n",
     "from azureml.core.compute_target import ComputeTargetException\n",
     "\n",
-    "cluster_name = \"your-compute-cluster\"\n",
+    "cluster_name = \"compute-cluster\"\n",
     "\n",
     "try:\n",
     "    # Check for existing compute target\n",

--- a/08A - Tuning Hyperparameters.ipynb
+++ b/08A - Tuning Hyperparameters.ipynb
@@ -179,7 +179,7 @@
     "\n",
     "You'll use the Azure Machine Learning compute cluster you created in an earlier lab (if it doesn't exist, it will be created).\n",
     "\n",
-    "> **Important**: Change *your-compute-cluster* to the name of your compute cluster in the code below before running it! Cluster names must be globally unique names between 2 to 16 characters in length. Valid characters are letters, digits, and the - character."
+    "> **Important**: Change *compute-cluster* to the name of your compute cluster in the code below before running it! Cluster names must be globally unique names between 2 to 16 characters in length. Valid characters are letters, digits, and the - character."
    ]
   },
   {
@@ -191,7 +191,7 @@
     "from azureml.core.compute import ComputeTarget, AmlCompute\n",
     "from azureml.core.compute_target import ComputeTargetException\n",
     "\n",
-    "cluster_name = \"your-compute-cluster\"\n",
+    "cluster_name = \"compute-cluster\"\n",
     "\n",
     "try:\n",
     "    # Check for existing compute target\n",

--- a/08B - Using Automated Machine Learning.ipynb
+++ b/08B - Using Automated Machine Learning.ipynb
@@ -89,7 +89,7 @@
     "\n",
     "You'll use the Azure Machine Learning compute cluster you created in an earlier lab (if it doesn't exist, it will be created).\n",
     "\n",
-    "> **Important**: Change *your-compute-cluster* to the name of your compute cluster in the code below before running it! Cluster names must be globally unique names between 2 to 16 characters in length. Valid characters are letters, digits, and the - character."
+    "> **Important**: Change *compute-cluster* to the name of your compute cluster in the code below before running it! Cluster names must be globally unique names between 2 to 16 characters in length. Valid characters are letters, digits, and the - character."
    ]
   },
   {
@@ -101,7 +101,7 @@
     "from azureml.core.compute import ComputeTarget, AmlCompute\n",
     "from azureml.core.compute_target import ComputeTargetException\n",
     "\n",
-    "cluster_name = \"your-compute-cluster\"\n",
+    "cluster_name = \"compute-cluster\"\n",
     "\n",
     "try:\n",
     "    # Check for existing compute target\n",

--- a/09A - Reviewing Automated Machine Learning Explanations.ipynb
+++ b/09A - Reviewing Automated Machine Learning Explanations.ipynb
@@ -44,7 +44,7 @@
     "\n",
     "You'll use the Azure Machine Learning compute cluster you created in an earlier lab (if it doesn't exist, it will be created).\n",
     "\n",
-    "> **Important**: Change *your-compute-cluster* to the name of your compute cluster in the code below before running it! Cluster names must be globally unique names between 2 to 16 characters in length. Valid characters are letters, digits, and the - character."
+    "> **Important**: Change *compute-cluster* to the name of your compute cluster in the code below before running it! Cluster names must be globally unique names between 2 to 16 characters in length. Valid characters are letters, digits, and the - character."
    ]
   },
   {
@@ -56,7 +56,7 @@
     "from azureml.core.compute import ComputeTarget, AmlCompute\n",
     "from azureml.core.compute_target import ComputeTargetException\n",
     "\n",
-    "cluster_name = \"your-compute-cluster\"\n",
+    "cluster_name = \"compute-cluster\"\n",
     "\n",
     "try:\n",
     "    # Check for existing compute target\n",

--- a/10B - Monitoring Data Drift.ipynb
+++ b/10B - Monitoring Data Drift.ipynb
@@ -171,7 +171,7 @@
     "\n",
     "To run the data drift monitor, you'll need a compute target. In this lab, you'll use the compute cluster you created previously (if it doesn't exist, it will be created).\n",
     "\n",
-    "> **Important**: Change *your-compute-cluster* to the name of your compute cluster in the code below before running it! Cluster names must be globally unique names between 2 to 16 characters in length. Valid characters are letters, digits, and the - character."
+    "> **Important**: Change *compute-cluster* to the name of your compute cluster in the code below before running it! Cluster names must be globally unique names between 2 to 16 characters in length. Valid characters are letters, digits, and the - character."
    ]
   },
   {
@@ -183,7 +183,7 @@
     "from azureml.core.compute import ComputeTarget, AmlCompute\n",
     "from azureml.core.compute_target import ComputeTargetException\n",
     "\n",
-    "cluster_name = \"your-compute-cluster\"\n",
+    "cluster_name = \"compute-cluster\"\n",
     "\n",
     "try:\n",
     "    # Check for existing compute target\n",


### PR DESCRIPTION
Cluster name can only have 16 characters, "your-cluster-name" has 20 characters causing the following error:

"Compute name is invalid. It can include letters, digits and dashes. It must start with a letter, end with a letter or digit, and be between 2 and 16 characters in length."